### PR TITLE
fix: initial layout sync without resize

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -53,6 +53,9 @@ async function main() {
   });
 
   const syncLayout = () => {
+    // On first load, Pixi's resizeTo can lag a tick; guard against 0-sized renderer.
+    if (app.renderer.width < 10 || app.renderer.height < 10) return;
+
     layout = computeBoardLayout({
       viewWidth: app.renderer.width,
       viewHeight: app.renderer.height,
@@ -65,7 +68,11 @@ async function main() {
   };
 
   app.renderer.on('resize', syncLayout);
+
+  // Kick initial sync after layout settles.
   syncLayout();
+  requestAnimationFrame(syncLayout);
+  setTimeout(syncLayout, 0);
 
   const input = new BoardInput(
     app,


### PR DESCRIPTION
Fixes an issue where the board/HUD were not visible until the first window resize.

- Guard against 0-sized renderer on first tick
- Run syncLayout on initial tick + RAF + setTimeout(0)

Quality gates: pnpm lint/typecheck/test green.