### PR TITLE
ci(pages): fix concurrency group

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages-${{ github.ref }}
+  group: pages
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Fixes Pages deploy action occasionally erroring while trying to cancel an already-finished deployment by using a stable concurrency group.