### PR TITLE
fix: ResizeObserver resize + #app 100vw/100vh

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -22,23 +22,23 @@ import { HudView } from './render/hud/hudView';
 import { groupDamageEventsByMatchStep } from './render/animations/script';
 import { damagePopupsStep } from './render/animations/damage';
 
-async function waitForStableHostSize(host: HTMLElement, minW: number, minH: number, maxFrames: number) {
-  for (let i = 0; i < maxFrames; i++) {
-    if (host.clientWidth >= minW && host.clientHeight >= minH) return;
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-  }
-}
-
 async function main() {
   const host = document.querySelector<HTMLDivElement>('#app');
   if (!host) throw new Error('Missing #app root element');
 
   const app = await createPixiApp(host);
 
-  // Wait until the host has a real size. Pixi resizeTo can start at 64x64 on first tick.
-  await waitForStableHostSize(host, 200, 200, 60);
-  // Force one resize so renderer matches actual host size.
-  app.renderer.resize(host.clientWidth, host.clientHeight);
+  // Ensure Pixi resizes reliably to the host element.
+  // - On first load, resizeTo can start at 64x64.
+  // - Host size can change after CSS/layout settles.
+  const ro = new ResizeObserver(() => {
+    app.resize();
+    syncLayout();
+  });
+  ro.observe(host);
+
+  // Force initial resize + layout sync.
+  app.resize();
 
   // Initial game state
   const seed = 123;

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -22,12 +22,17 @@ a:hover {
   color: #535bf2;
 }
 
+html,
+body {
+  width: 100%;
+  height: 100%;
+}
+
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  overflow: hidden;
 }
 
 h1 {
@@ -36,10 +41,11 @@ h1 {
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  text-align: left;
 }
 
 .logo {


### PR DESCRIPTION
Fixes initial Pixi canvas sizing issues by ensuring the host element is fullscreen and driving Pixi resize via ResizeObserver (app.resize()).

- CSS: html/body/#app set to 100% / 100vw+100vh, remove Vite template centering
- JS: observe #app size changes -> app.resize() + syncLayout()

Quality gates: pnpm lint/typecheck/test green.