### PR TITLE
fix: keep board stable during animations

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -21,6 +21,7 @@ import { enemyAttackFlashStep } from './render/animations/enemyAttack';
 import { HudView } from './render/hud/hudView';
 import { groupDamageEventsByMatchStep } from './render/animations/script';
 import { damagePopupsStep } from './render/animations/damage';
+import { waitStep } from './render/animations/wait';
 
 async function main() {
   const host = document.querySelector<HTMLDivElement>('#app');
@@ -33,7 +34,8 @@ async function main() {
   // - Host size can change after CSS/layout settles.
   const ro = new ResizeObserver(() => {
     app.resize();
-    syncLayout();
+    // Never full-sync during resize; only reposition current sprites.
+    syncLayout({ fullSync: false });
   });
   ro.observe(host);
 
@@ -64,7 +66,7 @@ async function main() {
     cellSize: 56,
   });
 
-  const syncLayout = () => {
+  const syncLayout = (opts: { fullSync?: boolean } = {}) => {
     // On first load, Pixi's resizeTo can lag a tick; guard against 0-sized renderer.
     if (app.renderer.width < 10 || app.renderer.height < 10) return;
 
@@ -76,15 +78,22 @@ async function main() {
       cellSize: 56,
     });
     boardView.setLayout(layout);
-    boardView.syncBoard(state.board);
+
+    // During animations the BoardView is a temporary "view state" and should NOT be reset
+    // from game state (otherwise tiles can appear to teleport/re-roll).
+    if (opts.fullSync && !animQueue.isRunning) {
+      boardView.syncBoard(state.board);
+    } else {
+      boardView.snapToLayout(layout);
+    }
   };
 
-  app.renderer.on('resize', syncLayout);
+  app.renderer.on('resize', () => syncLayout({ fullSync: false }));
 
   // Kick initial sync after layout settles.
-  syncLayout();
-  requestAnimationFrame(syncLayout);
-  setTimeout(syncLayout, 0);
+  syncLayout({ fullSync: true });
+  requestAnimationFrame(() => syncLayout({ fullSync: true }));
+  setTimeout(() => syncLayout({ fullSync: true }), 0);
 
   const input = new BoardInput(
     app,
@@ -125,6 +134,7 @@ async function main() {
         steps.push(highlightStep({ app, boardView, cells: cs.matches.flatMap((g) => g.cells) }));
         steps.push(clearStep({ app, boardView, cells: cs.clearedCells }));
         steps.push(dropStep({ app, boardView, layout, drops: cs.drops }));
+        steps.push(waitStep({ app, ms: 70, name: 'settle' }));
         steps.push(spawnStep({ app, boardView, layout, spawns: cs.spawns }));
 
         const dmg = dmgByStep.get(i) ?? [];
@@ -142,6 +152,8 @@ async function main() {
       state = res.state;
       hud.sync(state);
       boardView.syncBoard(state.board);
+      // After committing state, it's safe to do a full sync.
+      syncLayout({ fullSync: true });
     },
   );
 

--- a/apps/web/src/render/animations/wait.ts
+++ b/apps/web/src/render/animations/wait.ts
@@ -1,0 +1,12 @@
+import type { Application } from 'pixi.js';
+
+import type { AnimStep } from './queue';
+
+export function waitStep(params: { app: Application; ms: number; name?: string }): AnimStep {
+  return {
+    name: params.name ?? `wait(${params.ms}ms)`,
+    run: async () => {
+      await new Promise((r) => setTimeout(r, params.ms));
+    },
+  };
+}

--- a/apps/web/src/render/index.ts
+++ b/apps/web/src/render/index.ts
@@ -7,5 +7,6 @@ export * from './animations/steps';
 export * from './animations/enemyAttack';
 export * from './animations/invalidMove';
 export * from './animations/damage';
+export * from './animations/wait';
 export * from './hud/hudView';
 export * from './hud/hpBar';


### PR DESCRIPTION
Fixes visual tile teleport/reroll during animations.

- Never call boardView.syncBoard(state.board) while AnimationQueue is running
  - resize/layout changes only snap existing sprites to layout
- Add small settle delay between drop and spawn so new tiles do not appear instantly

Quality gates: pnpm lint/typecheck/test green.