### PR TITLE
EP-0004.1: RunState model + reducer scaffold

### DIFF
--- a/apps/web/src/game/run/__tests__/reducer.test.ts
+++ b/apps/web/src/game/run/__tests__/reducer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { initRunState, makeEmptyRunState } from '../state';
+import { runReducer } from '../reducer';
+
+describe('runReducer', () => {
+  it('NewRun -> battle on floor 0', () => {
+    const s0 = makeEmptyRunState();
+    const s1 = runReducer(s0, { type: 'NewRun', seed: 123, floorsCount: 5 });
+
+    expect(s1.screen).toBe('battle');
+    expect(s1.floorIndex).toBe(0);
+    expect(s1.seed).toBe(123);
+    expect(s1.combat).not.toBeNull();
+  });
+
+  it('BattleEnded(won) -> between (non-last floor)', () => {
+    const s0 = initRunState({ seed: 1, floorsCount: 5 });
+    const s1 = runReducer(s0, { type: 'BattleEnded', result: 'won' });
+    expect(s1.screen).toBe('between');
+  });
+
+  it('BattleEnded(won) -> victory on last floor', () => {
+    const s0 = initRunState({ seed: 1, floorsCount: 1 });
+    const s1 = runReducer(s0, { type: 'BattleEnded', result: 'won' });
+    expect(s1.screen).toBe('end');
+    expect(s1.endResult).toBe('victory');
+  });
+
+  it('BattleEnded(lost) -> defeat', () => {
+    const s0 = initRunState({ seed: 1, floorsCount: 5 });
+    const s1 = runReducer(s0, { type: 'BattleEnded', result: 'lost' });
+    expect(s1.screen).toBe('end');
+    expect(s1.endResult).toBe('defeat');
+  });
+});

--- a/apps/web/src/game/run/index.ts
+++ b/apps/web/src/game/run/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './state';
+export * from './reducer';

--- a/apps/web/src/game/run/reducer.ts
+++ b/apps/web/src/game/run/reducer.ts
@@ -1,0 +1,69 @@
+import type { RunAction, RunState } from './types';
+import { initFloorCombat, initRunState, makeEmptyRunState } from './state';
+import { DEFAULT_ENEMY, DEFAULT_HERO } from '../combat';
+
+export function runReducer(state: RunState, action: RunAction): RunState {
+  switch (action.type) {
+    case 'NewRun': {
+      return initRunState({ seed: action.seed, floorsCount: action.floorsCount });
+    }
+
+    case 'ContinueRunLoaded': {
+      return action.state;
+    }
+
+    case 'ResetRun': {
+      return makeEmptyRunState();
+    }
+
+    case 'StartBattle': {
+      if (state.endResult) return state;
+
+      const combat = initFloorCombat({
+        seed: state.seed,
+        floorIndex: state.floorIndex,
+        heroDef: DEFAULT_HERO,
+        enemyDef: DEFAULT_ENEMY,
+      });
+
+      return {
+        ...state,
+        screen: 'battle',
+        combat,
+      };
+    }
+
+    case 'BattleEnded': {
+      if (action.result === 'lost') {
+        return { ...state, screen: 'end', endResult: 'defeat' };
+      }
+
+      // won
+      const isLastFloor = state.floorIndex >= state.config.floorsCount - 1;
+      if (isLastFloor) {
+        return { ...state, screen: 'end', endResult: 'victory' };
+      }
+
+      return { ...state, screen: 'between' };
+    }
+
+    case 'NextFloor': {
+      const nextFloorIndex = Math.min(state.floorIndex + 1, state.config.floorsCount - 1);
+      return {
+        ...state,
+        floorIndex: nextFloorIndex,
+        screen: 'battle',
+        combat: initFloorCombat({
+          seed: state.seed,
+          floorIndex: nextFloorIndex,
+          heroDef: DEFAULT_HERO,
+          enemyDef: DEFAULT_ENEMY,
+        }),
+      };
+    }
+
+    default: {
+      return state;
+    }
+  }
+}

--- a/apps/web/src/game/run/state.ts
+++ b/apps/web/src/game/run/state.ts
@@ -1,0 +1,54 @@
+import { createBoard, createRng } from '../match3';
+import { DEFAULT_ENEMY, DEFAULT_HERO, initCombatState } from '../combat';
+import type { RunConfig, RunState } from './types';
+
+export const RUN_SCHEMA_VERSION = 1 as const;
+
+export function defaultRunConfig(overrides: Partial<RunConfig> = {}): RunConfig {
+  return {
+    floorsCount: overrides.floorsCount ?? 5,
+  };
+}
+
+export function makeEmptyRunState(): RunState {
+  return {
+    schemaVersion: RUN_SCHEMA_VERSION,
+    seed: 0,
+    config: defaultRunConfig(),
+    screen: 'start',
+    floorIndex: 0,
+    combat: null,
+    endResult: null,
+    heroDef: DEFAULT_HERO,
+    enemyDef: DEFAULT_ENEMY,
+  };
+}
+
+export function initRunState(params: { seed: number; floorsCount?: number }): RunState {
+  const config = defaultRunConfig({ floorsCount: params.floorsCount });
+
+  return {
+    schemaVersion: RUN_SCHEMA_VERSION,
+    seed: params.seed,
+    config,
+    screen: 'battle',
+    floorIndex: 0,
+    combat: initFloorCombat({ seed: params.seed, floorIndex: 0, heroDef: DEFAULT_HERO, enemyDef: DEFAULT_ENEMY }),
+    endResult: null,
+    heroDef: DEFAULT_HERO,
+    enemyDef: DEFAULT_ENEMY,
+  };
+}
+
+export function initFloorCombat(params: {
+  seed: number;
+  floorIndex: number;
+  heroDef: typeof DEFAULT_HERO;
+  enemyDef: typeof DEFAULT_ENEMY;
+}) {
+  // NOTE: deterministic per floor. For MVP we just offset the seed.
+  const rng = createRng((params.seed + params.floorIndex * 10_000) >>> 0);
+  const board = createBoard(rng, { width: 8, height: 8, allowInitialMatches: false });
+
+  return initCombatState({ hero: params.heroDef, enemy: params.enemyDef, board, rngState: rng.getState() });
+}

--- a/apps/web/src/game/run/types.ts
+++ b/apps/web/src/game/run/types.ts
@@ -1,0 +1,38 @@
+import type { CombatState, EnemyDef, HeroDef } from '../combat';
+
+export type RunScreen = 'start' | 'battle' | 'between' | 'end';
+
+export type RunEndResult = 'victory' | 'defeat';
+
+export type RunConfig = {
+  floorsCount: number;
+};
+
+export type RunState = {
+  schemaVersion: 1;
+
+  seed: number;
+  config: RunConfig;
+
+  screen: RunScreen;
+
+  // 0-based
+  floorIndex: number;
+
+  // Current battle (present when screen is battle; may be kept around for debug)
+  combat: CombatState | null;
+
+  endResult: RunEndResult | null;
+
+  // Data hooks for later EPs
+  heroDef: HeroDef;
+  enemyDef: EnemyDef;
+};
+
+export type RunAction =
+  | { type: 'NewRun'; seed: number; floorsCount?: number }
+  | { type: 'ContinueRunLoaded'; state: RunState }
+  | { type: 'ResetRun' }
+  | { type: 'StartBattle' }
+  | { type: 'BattleEnded'; result: 'won' | 'lost' }
+  | { type: 'NextFloor' };

--- a/docs/design-docs/state-model.md
+++ b/docs/design-docs/state-model.md
@@ -1,3 +1,57 @@
 # State model
 
-TODO: define canonical game state shape, serialization boundaries, and determinism constraints.
+This document defines the **canonical state shapes** and **serialization/determinism boundaries**.
+
+## Principles
+
+- **Game layer is pure + deterministic** (`apps/web/src/game/**`)
+  - No Pixi/DOM dependencies
+  - No `Math.random` (use seeded RNG)
+  - State transitions via explicit actions/reducers
+- **Render layer consumes state + events** (`apps/web/src/render/**`)
+  - No gameplay logic
+  - May keep temporary view state while animations run
+
+## CombatState (single encounter)
+
+Source of truth: `apps/web/src/game/combat/types.ts`.
+
+`CombatState` contains:
+- hero/enemy entities (base stats + modifiers + current hp)
+- match-3 board
+- `rngState` persisted from match-3 to keep deterministic cascades across moves
+- `turnCount` (valid turns only)
+- `status` (active/won/lost)
+
+## RunState (roguelike wrapper)
+
+Introduced in EP-0004.
+
+Source of truth: `apps/web/src/game/run/types.ts`.
+
+`RunState` wraps the battle state with roguelike progression:
+- `schemaVersion` — required for persistence
+- `seed` — run-level deterministic seed
+- `config.floorsCount` — MVP: 5 floors
+- `screen` — start | battle | between | end
+- `floorIndex` — 0-based
+- `combat` — current CombatState (only meaningful on battle screen)
+- `endResult` — victory | defeat
+
+### Transitions (MVP)
+
+- start → battle: New Run / Continue
+- battle → between: win (if not last floor)
+- battle → end: loss (defeat)
+- between → battle: Next floor
+- battle → end: win on last floor (victory)
+
+## Persistence boundary
+
+Only **RunState** is persisted (localStorage). Render state is never persisted.
+
+Run save must include:
+- `schemaVersion`
+- full `RunState` contents (including `combat.rngState`)
+
+On incompatible `schemaVersion`, persistence must safely reset.


### PR DESCRIPTION
Implements EP-0004 subtask: introduce initial RunState model + reducer scaffold in the pure game layer.

## Summary
- Add `apps/web/src/game/run/*` (RunState, RunConfig, RunAction, init helpers, reducer)
- Add basic Vitest coverage for reducer transitions
- Document canonical state model + persistence boundary in `docs/design-docs/state-model.md`

## Testing
- Not run in this environment yet (node/npm via nvm PATH issue on server). Will run once node/npm are wired into non-interactive shell.
