### PR TITLE
EP-0004.4: Integrate Run loop with battle (wire RunState to current combat+render)

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -59,6 +59,7 @@ async function main() {
   const loaded = loadRunFromLocalStorage();
   if (loaded) {
     // Show Start screen with Continue rather than auto-resuming.
+    // The saved state will be restored when the user presses Continue.
     runState = { ...loaded, screen: 'start' };
   }
 
@@ -83,87 +84,65 @@ async function main() {
   app.stage.addChild(hud.root);
   hud.sync(state);
 
+  const syncFromRun = (next: RunState) => {
+    runState = next;
+
+    if (!runState.combat) {
+      runState = {
+        ...runState,
+        combat: initFloorCombat({ seed: runState.seed, floorIndex: runState.floorIndex, heroDef: DEFAULT_HERO, enemyDef: DEFAULT_ENEMY }),
+      };
+    }
+
+    const combat = runState.combat;
+    if (!combat) throw new Error('Missing combat state after syncFromRun');
+    state = combat;
+    hud.sync(state);
+    boardView.syncBoard(state.board);
+    syncLayout({ fullSync: true });
+    overlays.render(runState);
+  };
+
   // UI overlays
   const overlays = createOverlays({
     onNewRun: (seed) => {
       const s = seed ?? (Date.now() >>> 0);
-      runState = initRunState({ seed: s, floorsCount: 5 });
-      saveRunToLocalStorage(runState);
-
-      state = runState.combat!;
-      hud.sync(state);
-      boardView.syncBoard(state.board);
-      syncLayout({ fullSync: true });
-      overlays.render(runState);
+      const next = initRunState({ seed: s, floorsCount: 5 });
+      saveRunToLocalStorage(next);
+      syncFromRun(next);
     },
     onContinue: () => {
       const loadedRun = loadRunFromLocalStorage();
       if (!loadedRun) return;
 
-      // If the run already ended, resume into the end screen.
+      // Ended run → end screen.
       if (loadedRun.endResult) {
-        runState = { ...loadedRun, screen: 'end' };
-        overlays.render(runState);
-        // Keep current battle visuals; user can start a new run from End screen.
+        const next = { ...loadedRun, screen: 'end' as const };
+        saveRunToLocalStorage(next);
+        syncFromRun(next);
         return;
       }
 
-      // Active run: ensure we have combat state.
-      runState = { ...loadedRun, screen: 'battle' };
-
-      if (!runState.combat) {
-        // Safe fallback for corrupted/tampered saves.
-        runState = {
-          ...runState,
-          combat: initFloorCombat({
-            seed: runState.seed,
-            floorIndex: runState.floorIndex,
-            heroDef: DEFAULT_HERO,
-            enemyDef: DEFAULT_ENEMY,
-          }),
-        };
-      }
-
-      saveRunToLocalStorage(runState);
-
-      const combat = runState.combat;
-      if (!combat) throw new Error('Missing combat state after Continue');
-      state = combat;
-      hud.sync(state);
-      boardView.syncBoard(state.board);
-      syncLayout({ fullSync: true });
-      overlays.render(runState);
+      // Restore whatever screen we were on (battle/between).
+      const next = { ...loadedRun };
+      saveRunToLocalStorage(next);
+      syncFromRun(next);
     },
     onReset: () => {
       clearRunFromLocalStorage();
-      runState = makePreviewRun();
-
-      state = runState.combat!;
-      hud.sync(state);
-      boardView.syncBoard(state.board);
-      syncLayout({ fullSync: true });
-      overlays.render(runState);
+      const next = makePreviewRun();
+      syncFromRun(next);
     },
     onNextBattle: () => {
-      runState = runReducer(runState, { type: 'NextFloor' });
-      saveRunToLocalStorage(runState);
-
-      state = runState.combat!;
-      hud.sync(state);
-      boardView.syncBoard(state.board);
-      syncLayout({ fullSync: true });
-      overlays.render(runState);
+      const next = runReducer(runState, { type: 'NextFloor' });
+      saveRunToLocalStorage(next);
+      syncFromRun(next);
     },
     onStartNewAfterEnd: () => {
       const s = Date.now() >>> 0;
-      runState = initRunState({ seed: s, floorsCount: 5 });
-      saveRunToLocalStorage(runState);
-
-      state = runState.combat!;
-      hud.sync(state);
-      boardView.syncBoard(state.board);
-      syncLayout({ fullSync: true });
-      overlays.render(runState);
+      const next = initRunState({ seed: s, floorsCount: 5 });
+      saveRunToLocalStorage(next);
+      syncFromRun(next);
     },
   });
   overlays.mount(host);
@@ -290,6 +269,22 @@ async function main() {
     lastSelected = sel ? { ...sel } : null;
     boardView.setSelected(lastSelected);
   });
+
+  // Debug hooks for Playwright e2e integration tests.
+  (window as unknown as Record<string, unknown>).__TRR_DEBUG__ = {
+    forceWin: () => {
+      state = { ...state, status: 'won' };
+      runState = runReducer({ ...runState, combat: state }, { type: 'BattleEnded', result: 'won' });
+      saveRunToLocalStorage(runState);
+      overlays.render(runState);
+    },
+    forceLose: () => {
+      state = { ...state, status: 'lost' };
+      runState = runReducer({ ...runState, combat: state }, { type: 'BattleEnded', result: 'lost' });
+      saveRunToLocalStorage(runState);
+      overlays.render(runState);
+    },
+  };
 
   // keep for now
   void input;

--- a/docs/exec-plans/active/EP-0004-run-loop.md
+++ b/docs/exec-plans/active/EP-0004-run-loop.md
@@ -59,7 +59,7 @@ Decision to be recorded in docs/design-docs.
 - [ ] Add end screen: Victory/Defeat
 - [ ] Add between-fights screen (MVP): Floor N/M + “Next battle” button
 - [x] Screenshot regression baseline (Playwright): capture current battle screen before UI changes
-- [ ] Integrate battle screen with existing combat+render pipeline
+- [ ] Integrate battle screen with existing combat+render pipeline (issue #18)
 - [x] Persistence: localStorage save/load, schemaVersion + safe reset
 - [x] Tests:
   - [x] serialize/deserialize + schema version fallback
@@ -83,6 +83,26 @@ Decision to be recorded in docs/design-docs.
   - Preconditions: a save exists
   - Steps: click Reset → refresh
   - Expected: Continue is not available
+
+- **TC-INTEG-001: Win transitions to Between screen and blocks input**
+  - Preconditions: in battle
+  - Steps: force a win (debug/test hook) or play until enemy hp=0
+  - Expected: Between overlay appears; board input blocked
+
+- **TC-INTEG-002: Next battle starts new combat state on next floor**
+  - Preconditions: Between screen visible after win
+  - Steps: click Next battle
+  - Expected: battle screen shows; floorIndex increments; combat resets
+
+- **TC-INTEG-003: Lose transitions to End screen**
+  - Preconditions: in battle
+  - Steps: force a loss (debug/test hook) or play until hero hp=0
+  - Expected: End overlay appears with Defeat
+
+- **TC-INTEG-004: Refresh after Between/End resumes into Start with Continue**
+  - Preconditions: reach Between or End so save exists
+  - Steps: refresh
+  - Expected: Start screen shows; Continue enabled; clicking Continue restores correct overlay state
 
 
 - **TC-PERSIST-001: Save run on New Run**

--- a/tests/e2e/integration.spec.ts
+++ b/tests/e2e/integration.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+
+// These tests use the debug hooks registered in main.ts.
+
+test('integration: win -> between, next battle -> battle', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'New Run' }).click();
+
+  // Force win via debug hook.
+  await page.evaluate(() => {
+    // @ts-expect-error debug
+    window.__TRR_DEBUG__.forceWin();
+  });
+
+  await expect(page.locator('[data-screen="between"]')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next battle' }).click();
+
+  // Overlay should hide again.
+  await expect(page.locator('[data-screen="between"]')).toHaveCount(0);
+
+  // Baseline battle UI should still render.
+  await expect(page.locator('canvas')).toBeVisible();
+});
+
+test('integration: lose -> end screen', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'New Run' }).click();
+
+  await page.evaluate(() => {
+    // @ts-expect-error debug
+    window.__TRR_DEBUG__.forceLose();
+  });
+
+  await expect(page.locator('[data-screen="end"]')).toBeVisible();
+});


### PR DESCRIPTION
Closes #18.

## What
Wire battle results into RunState transitions and add CLI/browser verification.

## Changes
- Refactor main.ts: central `syncFromRun()` to keep render in sync with RunState
- Continue now restores saved screen (battle/between/end) safely
- Add Playwright integration e2e tests using debug hooks:
  - win -> between -> next battle
  - lose -> end
- EP-0004 updated with integration test cases

## QA
- `pnpm -C apps/web lint` ✅
- `pnpm -C apps/web typecheck` ✅
- `pnpm test` ✅
- `pnpm docs:lint` ✅
- `pnpm e2e` ✅
