### PR TITLE
docs(EP-0004): run loop product spec + status update

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,9 +20,10 @@
 
 ## What’s next
 
-- Finish EP-0000 (scaffold web app + CI + docs-lint).
+- Complete EP-0004 docs + tighten run flow (then move to EP-0005 rewards/upgrades).
 
 ## Next EP suggestions
 
-- EP-0003: connect combat+match3 to a renderer-facing event stream + minimal debug UI.
-- EP-0004: richer combat intents/effects (buffs/debuffs), enemy AI intents.
+- EP-0005: rewards/upgrades (3 choices) + data-driven upgrades.
+- EP-0006: enemy roster + abilities.
+- EP-0007: scaling/map-lite.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -5,3 +5,4 @@
 - Tiles: `tiles.md`
 - Entities & stats: `entities-and-stats.md`
 - Enemies: `enemies.md`
+- Run loop: `run-loop.md`

--- a/docs/product-specs/run-loop.md
+++ b/docs/product-specs/run-loop.md
@@ -1,0 +1,68 @@
+# Run loop (EP-0004)
+
+This spec describes the MVP roguelike **run wrapper** around the existing single-encounter battle.
+
+## Screens
+
+MVP screens are implemented as **DOM overlays** on top of the Pixi battle view.
+
+- **Start**
+  - Actions:
+    - **New Run**: starts a deterministic run (currently fixed seed for MVP/testing)
+    - **Continue**: loads saved run (enabled only if a valid save exists)
+    - **Reset**: clears saved run
+- **Battle**
+  - The existing match-3 + combat experience
+  - Input is disabled while animations run
+- **Between fights**
+  - Shows floor progress: `Floor N / M`
+  - Action: **Next battle**
+- **End**
+  - Shows **Victory** or **Defeat**
+  - Action: **Start new run**
+
+## Run structure
+
+- A run is a sequence of floors (MVP: `floorsCount = 5`).
+- Floor index is **0-based** in state; UI displays 1-based.
+
+### Transitions
+
+- Start → Battle: New Run
+- Start → Battle/Between/End: Continue (restores saved screen)
+- Battle → Between: win on a non-last floor
+- Battle → End: loss
+- Battle → End: win on last floor (victory)
+- Between → Battle: Next battle
+
+## Determinism
+
+- A run has a `seed`.
+- Per-floor battle initialization must be deterministic from `(seed, floorIndex)`.
+
+## Persistence (MVP)
+
+### Storage key
+
+- `localStorage` key: `three-rouge-round.run.save`
+
+### Schema versioning
+
+- Save payload is wrapped in an envelope:
+  - `schemaVersion`
+  - `state` (RunState)
+
+If `schemaVersion` mismatches or payload is malformed, the save is ignored (safe fallback).
+
+### Expected behavior
+
+- If a valid save exists, **Continue** is enabled.
+- If there is no save (or save is invalid), **Continue** is disabled.
+- **Reset** clears the saved run.
+
+## Acceptance scenarios (MVP)
+
+1) Start → New Run → Battle
+2) Win → Between → Next battle → Battle
+3) Lose → End
+4) Refresh after saving → Start with Continue enabled → Continue restores run


### PR DESCRIPTION
Adds missing EP-0004 product spec for the run loop and updates docs indices.

## Changes
- Add `docs/product-specs/run-loop.md`
- Link from `docs/product-specs/index.md`
- Update `docs/STATUS.md` next steps

## QA
- `pnpm docs:lint` ✅
- `pnpm e2e` ✅
