### PR TITLE
EP-0005.2: Reward generator (3 choices) deterministic

### DIFF
--- a/apps/web/src/game/upgrades/__tests__/rewards.test.ts
+++ b/apps/web/src/game/upgrades/__tests__/rewards.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateRewardChoices } from '../rewards';
+
+const pool = [
+  { id: 'a', name: 'a', description: 'a', apply: (s: unknown) => s as never },
+  { id: 'b', name: 'b', description: 'b', apply: (s: unknown) => s as never },
+  { id: 'c', name: 'c', description: 'c', apply: (s: unknown) => s as never },
+  { id: 'd', name: 'd', description: 'd', apply: (s: unknown) => s as never },
+] as const;
+
+describe('generateRewardChoices', () => {
+  it('returns exactly 3 unique choices by default', () => {
+    const res = generateRewardChoices({ seed: 1, floorIndex: 0, pool });
+    expect(res).toHaveLength(3);
+    expect(new Set(res.map((x) => x.id)).size).toBe(3);
+  });
+
+  it('is deterministic for same seed+floor', () => {
+    const a = generateRewardChoices({ seed: 123, floorIndex: 2, pool });
+    const b = generateRewardChoices({ seed: 123, floorIndex: 2, pool });
+    expect(a).toEqual(b);
+  });
+
+  it('different floorIndex is deterministic per floor', () => {
+    const a0 = generateRewardChoices({ seed: 123, floorIndex: 0, pool });
+    const a1 = generateRewardChoices({ seed: 123, floorIndex: 1, pool });
+
+    // Not required to differ, but must be deterministic.
+    expect(generateRewardChoices({ seed: 123, floorIndex: 0, pool })).toEqual(a0);
+    expect(generateRewardChoices({ seed: 123, floorIndex: 1, pool })).toEqual(a1);
+  });
+
+  it('handles small pool by returning <= pool length', () => {
+    const res = generateRewardChoices({ seed: 1, floorIndex: 0, pool: pool.slice(0, 2), count: 3 });
+    expect(res).toHaveLength(2);
+  });
+});

--- a/apps/web/src/game/upgrades/index.ts
+++ b/apps/web/src/game/upgrades/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './defs';
 export * from './apply';
+export * from './rewards';

--- a/apps/web/src/game/upgrades/rewards.ts
+++ b/apps/web/src/game/upgrades/rewards.ts
@@ -1,0 +1,38 @@
+import { createRng } from '../match3';
+import { UPGRADE_DEFS } from './defs';
+import type { UpgradeDef, UpgradeId } from './types';
+
+export type RewardChoice = {
+  id: UpgradeId;
+};
+
+export type RewardGenParams = {
+  seed: number;
+  floorIndex: number;
+  count?: number;
+
+  // Override pool for tests.
+  pool?: readonly UpgradeDef[];
+};
+
+export function generateRewardChoices(params: RewardGenParams): RewardChoice[] {
+  const count = params.count ?? 3;
+  const pool = params.pool ?? UPGRADE_DEFS;
+  if (count <= 0) return [];
+  if (pool.length === 0) return [];
+
+  // Deterministic RNG derived from run seed + floor index.
+  const rng = createRng((params.seed + params.floorIndex * 1_000_003) >>> 0);
+
+  // Sample without replacement.
+  const choices: RewardChoice[] = [];
+  const available = pool.map((d) => d.id);
+
+  while (choices.length < count && available.length > 0) {
+    const idx = rng.nextInt(available.length);
+    const id = available.splice(idx, 1)[0];
+    choices.push({ id });
+  }
+
+  return choices;
+}

--- a/docs/exec-plans/active/EP-0005-upgrades.md
+++ b/docs/exec-plans/active/EP-0005-upgrades.md
@@ -27,8 +27,8 @@ After winning a battle, offer **3 deterministic upgrade choices**, allow the pla
 - [x] Product spec: `docs/product-specs/progression.md`
 - [x] Product spec: `docs/product-specs/upgrades.md`
 - [x] Implement UpgradeDef registry + `applyUpgrade` (pure)
-- [ ] Deterministic reward generator (3 choices)
-- [ ] Rewards UI + integrate after win
+- [ ] Deterministic reward generator (3 choices) (issue #25)
+- [ ] Rewards UI + integrate after win (issue #26)
 - [ ] QA: Playwright CLI verification + baseline screenshot regression stays green
 - [ ] Quality gates: lint/typecheck/test/docs:lint + CI green
 
@@ -41,6 +41,19 @@ After winning a battle, offer **3 deterministic upgrade choices**, allow the pla
 - **TC-UPG-002: unknown upgrade id is a no-op**
   - Steps: apply unknown id
   - Expected: state unchanged
+
+- **TC-REW-001: generator returns exactly 3 choices**
+  - Preconditions: upgrade pool has >= 3 upgrades
+  - Steps: generate rewards for (seed, floorIndex)
+  - Expected: 3 unique upgrade ids
+
+- **TC-REW-002: generator is deterministic**
+  - Steps: generate twice for same (seed, floorIndex)
+  - Expected: identical results
+
+- **TC-REW-003: generator varies across floors**
+  - Steps: generate for floorIndex=0 vs floorIndex=1 (same seed)
+  - Expected: results may differ (not required always), but must be deterministic per floor
 
 ## Tests
 


### PR DESCRIPTION
Closes #25.

## What
Add deterministic reward generator for upgrades (3 choices, sample without replacement).

## Changes
- `generateRewardChoices({ seed, floorIndex })` (pure)
- Unit tests: count=3 unique, determinism, small pool behavior
- EP-0005 updated with reward generator test cases

## QA
- `pnpm -C apps/web lint` ✅
- `pnpm -C apps/web typecheck` ✅
- `pnpm test` ✅
- `pnpm docs:lint` ✅
- `pnpm e2e` ✅ (baseline screenshot regression stays green)
