### PR TITLE
EP-0005.3: Rewards UI (3 cards) + integrate after win

### DIFF
--- a/apps/web/src/game/run/__tests__/reducer.test.ts
+++ b/apps/web/src/game/run/__tests__/reducer.test.ts
@@ -14,10 +14,10 @@ describe('runReducer', () => {
     expect(s1.combat).not.toBeNull();
   });
 
-  it('BattleEnded(won) -> between (non-last floor)', () => {
+  it('BattleEnded(won) -> reward (non-last floor)', () => {
     const s0 = initRunState({ seed: 1, floorsCount: 5 });
     const s1 = runReducer(s0, { type: 'BattleEnded', result: 'won' });
-    expect(s1.screen).toBe('between');
+    expect(s1.screen).toBe('reward');
   });
 
   it('BattleEnded(won) -> victory on last floor', () => {

--- a/apps/web/src/game/run/reducer.ts
+++ b/apps/web/src/game/run/reducer.ts
@@ -1,6 +1,7 @@
 import type { RunAction, RunState } from './types';
 import { initFloorCombat, initRunState, makeEmptyRunState } from './state';
 import { DEFAULT_ENEMY, DEFAULT_HERO } from '../combat';
+import { applyUpgrade } from '../upgrades';
 
 export function runReducer(state: RunState, action: RunAction): RunState {
   switch (action.type) {
@@ -44,7 +45,13 @@ export function runReducer(state: RunState, action: RunAction): RunState {
         return { ...state, screen: 'end', endResult: 'victory' };
       }
 
-      return { ...state, screen: 'between' };
+      return { ...state, screen: 'reward' };
+    }
+
+    case 'UpgradeChosen': {
+      // Apply upgrade and proceed to between-fights.
+      const next = applyUpgrade(state, action.upgradeId);
+      return { ...next, screen: 'between' };
     }
 
     case 'NextFloor': {

--- a/apps/web/src/game/run/types.ts
+++ b/apps/web/src/game/run/types.ts
@@ -1,6 +1,6 @@
 import type { CombatState, EnemyDef, HeroDef } from '../combat';
 
-export type RunScreen = 'start' | 'battle' | 'between' | 'end';
+export type RunScreen = 'start' | 'battle' | 'reward' | 'between' | 'end';
 
 export type RunEndResult = 'victory' | 'defeat';
 
@@ -35,4 +35,5 @@ export type RunAction =
   | { type: 'ResetRun' }
   | { type: 'StartBattle' }
   | { type: 'BattleEnded'; result: 'won' | 'lost' }
+  | { type: 'UpgradeChosen'; upgradeId: string }
   | { type: 'NextFloor' };

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -123,7 +123,7 @@ async function main() {
         return;
       }
 
-      // Restore whatever screen we were on (battle/between).
+      // Restore whatever screen we were on (battle/reward/between).
       const next = { ...loadedRun };
       saveRunToLocalStorage(next);
       syncFromRun(next);
@@ -131,6 +131,11 @@ async function main() {
     onReset: () => {
       clearRunFromLocalStorage();
       const next = makePreviewRun();
+      syncFromRun(next);
+    },
+    onChooseUpgrade: (upgradeId) => {
+      const next = runReducer(runState, { type: 'UpgradeChosen', upgradeId });
+      saveRunToLocalStorage(next);
       syncFromRun(next);
     },
     onNextBattle: () => {

--- a/apps/web/src/ui/overlays.ts
+++ b/apps/web/src/ui/overlays.ts
@@ -2,6 +2,7 @@ import './overlays.css';
 
 import { clearRun, loadRun, makeEmptyRunState, RUN_SAVE_KEY, saveRun } from '../game/run';
 import type { RunState } from '../game/run';
+import { generateRewardChoices, UPGRADE_DEF_BY_ID } from '../game/upgrades';
 
 export type OverlayApi = {
   mount(host: HTMLElement): void;
@@ -14,6 +15,7 @@ type Handlers = {
   onNewRun: (seed?: number) => void;
   onContinue: () => void;
   onReset: () => void;
+  onChooseUpgrade: (upgradeId: string) => void;
   onNextBattle: () => void;
   onStartNewAfterEnd: () => void;
 };
@@ -75,6 +77,55 @@ export function createOverlays(handlers: Handlers): OverlayApi {
     return card;
   };
 
+  const renderReward = (state: RunState) => {
+    const card = document.createElement('div');
+    card.className = 'overlay-card';
+    card.setAttribute('data-screen', 'reward');
+
+    const h = document.createElement('h1');
+    h.textContent = 'Choose an upgrade';
+
+    const p = document.createElement('p');
+    p.textContent = 'Pick 1 of 3.';
+
+    const choices = generateRewardChoices({ seed: state.seed, floorIndex: state.floorIndex });
+
+    const list = document.createElement('div');
+    list.style.display = 'grid';
+    list.style.gap = '10px';
+
+    for (const c of choices) {
+      const def = UPGRADE_DEF_BY_ID[c.id];
+      const item = document.createElement('div');
+      item.style.padding = '10px';
+      item.style.borderRadius = '10px';
+      item.style.border = '1px solid rgba(255,255,255,0.12)';
+      item.style.background = 'rgba(255,255,255,0.06)';
+
+      const name = document.createElement('div');
+      name.textContent = def?.name ?? c.id;
+      name.style.fontWeight = '600';
+
+      const desc = document.createElement('div');
+      desc.textContent = def?.description ?? '';
+      desc.style.opacity = '0.85';
+      desc.style.marginTop = '4px';
+
+      const actions = document.createElement('div');
+      actions.className = 'overlay-actions';
+
+      const pick = makeButton('Pick', { primary: true });
+      pick.onclick = () => handlers.onChooseUpgrade(c.id);
+      actions.append(pick);
+
+      item.append(name, desc, actions);
+      list.append(item);
+    }
+
+    card.append(h, p, list);
+    return card;
+  };
+
   const renderBetween = (state: RunState) => {
     const card = document.createElement('div');
     card.className = 'overlay-card';
@@ -124,6 +175,11 @@ export function createOverlays(handlers: Handlers): OverlayApi {
 
     if (state.screen === 'start') {
       setCard(renderStart());
+      return;
+    }
+
+    if (state.screen === 'reward') {
+      setCard(renderReward(state));
       return;
     }
 

--- a/docs/exec-plans/active/EP-0005-upgrades.md
+++ b/docs/exec-plans/active/EP-0005-upgrades.md
@@ -27,7 +27,7 @@ After winning a battle, offer **3 deterministic upgrade choices**, allow the pla
 - [x] Product spec: `docs/product-specs/progression.md`
 - [x] Product spec: `docs/product-specs/upgrades.md`
 - [x] Implement UpgradeDef registry + `applyUpgrade` (pure)
-- [ ] Deterministic reward generator (3 choices) (issue #25)
+- [x] Deterministic reward generator (3 choices) (issue #25)
 - [ ] Rewards UI + integrate after win (issue #26)
 - [ ] QA: Playwright CLI verification + baseline screenshot regression stays green
 - [ ] Quality gates: lint/typecheck/test/docs:lint + CI green
@@ -54,6 +54,18 @@ After winning a battle, offer **3 deterministic upgrade choices**, allow the pla
 - **TC-REW-003: generator varies across floors**
   - Steps: generate for floorIndex=0 vs floorIndex=1 (same seed)
   - Expected: results may differ (not required always), but must be deterministic per floor
+
+- **TC-REW-UI-001: Win -> rewards screen shows 3 upgrade cards**
+  - Steps: win a battle
+  - Expected: reward overlay shows 3 unique upgrade options
+
+- **TC-REW-UI-002: Selecting an upgrade applies it and proceeds to between-fights**
+  - Steps: choose one upgrade
+  - Expected: heroDef updated; reward screen closes; Between screen appears
+
+- **TC-REW-UI-003: Reward flow does not break baseline battle visuals**
+  - Steps: start new run; ensure baseline screenshot still matches
+  - Expected: screenshot regression passes
 
 ## Tests
 

--- a/tests/e2e/integration.spec.ts
+++ b/tests/e2e/integration.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 // These tests use the debug hooks registered in main.ts.
 
-test('integration: win -> between, next battle -> battle', async ({ page }) => {
+test('integration: win -> reward -> between -> next battle -> battle', async ({ page }) => {
   await page.goto('/');
 
   await page.getByRole('button', { name: 'New Run' }).click();
@@ -12,6 +12,11 @@ test('integration: win -> between, next battle -> battle', async ({ page }) => {
     // @ts-expect-error debug
     window.__TRR_DEBUG__.forceWin();
   });
+
+  await expect(page.locator('[data-screen="reward"]')).toBeVisible();
+
+  // Pick first upgrade.
+  await page.getByRole('button', { name: 'Pick' }).first().click();
 
   await expect(page.locator('[data-screen="between"]')).toBeVisible();
 


### PR DESCRIPTION
Closes #26.

## What
Add reward selection screen after battle wins and wire upgrade application into the run loop.

## Changes
- New RunScreen: `reward`
- On battle win (non-last floor): Battle → Reward
- Reward screen shows 3 deterministic upgrade options and allows picking 1
- After pick: apply upgrade → Between screen
- Playwright e2e updated: win flow now covers reward → between → next battle
- EP-0005 checklist + test cases updated

## QA
- `pnpm -C apps/web lint` ✅
- `pnpm -C apps/web typecheck` ✅
- `pnpm test` ✅
- `pnpm docs:lint` ✅
- `pnpm e2e` ✅ (baseline screenshot regression stays green)
