### PR TITLE
EP-0006.1: EnemyDefs + deterministic selection by floor

### DIFF
--- a/apps/web/src/game/enemies/__tests__/select.test.ts
+++ b/apps/web/src/game/enemies/__tests__/select.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectEnemy } from '../select';
+
+describe('selectEnemy', () => {
+  it('is deterministic for same seed+floor', () => {
+    const a = selectEnemy({ seed: 123, floorIndex: 0, floorsCount: 5 }).id;
+    const b = selectEnemy({ seed: 123, floorIndex: 0, floorsCount: 5 }).id;
+    expect(a).toBe(b);
+  });
+
+  it('returns boss on last floor', () => {
+    const e = selectEnemy({ seed: 123, floorIndex: 4, floorsCount: 5 });
+    expect(e.id).toBe('boss');
+  });
+});

--- a/apps/web/src/game/enemies/defs.ts
+++ b/apps/web/src/game/enemies/defs.ts
@@ -1,0 +1,42 @@
+import type { EnemyDef } from '../combat';
+
+export const ENEMY_DEFS = [
+  {
+    id: 'slime',
+    name: 'Slime',
+    baseStats: { hpMax: 40, atk: 8, armor: 0, matk: 0, marmor: 0 },
+    attackEveryTurns: 3,
+    attackPower: 7,
+    attackType: 'phys',
+  },
+  {
+    id: 'bandit',
+    name: 'Bandit',
+    baseStats: { hpMax: 28, atk: 12, armor: 1, matk: 0, marmor: 0 },
+    attackEveryTurns: 2,
+    attackPower: 9,
+    attackType: 'phys',
+  },
+  {
+    id: 'mage',
+    name: 'Mage',
+    baseStats: { hpMax: 26, atk: 6, armor: 0, matk: 12, marmor: 1 },
+    attackEveryTurns: 2,
+    attackPower: 9,
+    attackType: 'magic',
+  },
+  {
+    id: 'boss',
+    name: 'Boss',
+    baseStats: { hpMax: 80, atk: 14, armor: 2, matk: 0, marmor: 2 },
+    attackEveryTurns: 2,
+    attackPower: 12,
+    attackType: 'phys',
+  },
+] satisfies EnemyDef[];
+
+export const ENEMY_DEF_BY_ID: Record<string, EnemyDef> = Object.fromEntries(
+  ENEMY_DEFS.map((d) => [d.id, d] as const),
+);
+
+export const BOSS_ENEMY_ID = 'boss' as const;

--- a/apps/web/src/game/enemies/index.ts
+++ b/apps/web/src/game/enemies/index.ts
@@ -1,0 +1,2 @@
+export * from './defs';
+export * from './select';

--- a/apps/web/src/game/enemies/select.ts
+++ b/apps/web/src/game/enemies/select.ts
@@ -1,0 +1,22 @@
+import { createRng } from '../match3';
+import { BOSS_ENEMY_ID, ENEMY_DEFS, ENEMY_DEF_BY_ID } from './defs';
+import type { EnemyDef } from '../combat';
+
+export function selectEnemy(params: {
+  seed: number;
+  floorIndex: number;
+  floorsCount: number;
+}): EnemyDef {
+  const { seed, floorIndex, floorsCount } = params;
+
+  // Boss on last floor.
+  if (floorIndex >= floorsCount - 1) {
+    return ENEMY_DEF_BY_ID[BOSS_ENEMY_ID];
+  }
+
+  const roster = ENEMY_DEFS.filter((e) => e.id !== BOSS_ENEMY_ID);
+
+  const rng = createRng((seed + floorIndex * 97_133) >>> 0);
+  const idx = rng.nextInt(roster.length);
+  return roster[idx];
+}

--- a/apps/web/src/game/run/reducer.ts
+++ b/apps/web/src/game/run/reducer.ts
@@ -1,6 +1,6 @@
 import type { RunAction, RunState } from './types';
 import { initFloorCombat, initRunState, makeEmptyRunState } from './state';
-import { DEFAULT_ENEMY, DEFAULT_HERO } from '../combat';
+import { DEFAULT_HERO } from '../combat';
 import { applyUpgrade } from '../upgrades';
 
 export function runReducer(state: RunState, action: RunAction): RunState {
@@ -23,8 +23,8 @@ export function runReducer(state: RunState, action: RunAction): RunState {
       const combat = initFloorCombat({
         seed: state.seed,
         floorIndex: state.floorIndex,
+        floorsCount: state.config.floorsCount,
         heroDef: DEFAULT_HERO,
-        enemyDef: DEFAULT_ENEMY,
       });
 
       return {
@@ -63,8 +63,8 @@ export function runReducer(state: RunState, action: RunAction): RunState {
         combat: initFloorCombat({
           seed: state.seed,
           floorIndex: nextFloorIndex,
+          floorsCount: state.config.floorsCount,
           heroDef: DEFAULT_HERO,
-          enemyDef: DEFAULT_ENEMY,
         }),
       };
     }

--- a/apps/web/src/game/run/state.ts
+++ b/apps/web/src/game/run/state.ts
@@ -1,5 +1,6 @@
 import { createBoard, createRng } from '../match3';
-import { DEFAULT_ENEMY, DEFAULT_HERO, initCombatState } from '../combat';
+import { DEFAULT_HERO, initCombatState } from '../combat';
+import { selectEnemy } from '../enemies';
 import type { RunConfig, RunState } from './types';
 
 export const RUN_SCHEMA_VERSION = 1 as const;
@@ -20,7 +21,7 @@ export function makeEmptyRunState(): RunState {
     combat: null,
     endResult: null,
     heroDef: DEFAULT_HERO,
-    enemyDef: DEFAULT_ENEMY,
+    enemyDef: selectEnemy({ seed: 0, floorIndex: 0, floorsCount: 5 }),
   };
 }
 
@@ -28,7 +29,7 @@ export function initRunState(params: { seed: number; floorsCount?: number }): Ru
   const config = defaultRunConfig({ floorsCount: params.floorsCount });
 
   const heroDef = DEFAULT_HERO;
-  const enemyDef = DEFAULT_ENEMY;
+  const enemyDef = selectEnemy({ seed: params.seed, floorIndex: 0, floorsCount: config.floorsCount });
 
   return {
     schemaVersion: RUN_SCHEMA_VERSION,
@@ -36,7 +37,7 @@ export function initRunState(params: { seed: number; floorsCount?: number }): Ru
     config,
     screen: 'battle',
     floorIndex: 0,
-    combat: initFloorCombat({ seed: params.seed, floorIndex: 0, heroDef, enemyDef }),
+    combat: initFloorCombat({ seed: params.seed, floorIndex: 0, floorsCount: config.floorsCount, heroDef }),
     endResult: null,
     heroDef,
     enemyDef,
@@ -46,12 +47,14 @@ export function initRunState(params: { seed: number; floorsCount?: number }): Ru
 export function initFloorCombat(params: {
   seed: number;
   floorIndex: number;
+  floorsCount: number;
   heroDef: typeof DEFAULT_HERO;
-  enemyDef: typeof DEFAULT_ENEMY;
 }) {
   // NOTE: deterministic per floor. For MVP we just offset the seed.
   const rng = createRng((params.seed + params.floorIndex * 10_000) >>> 0);
   const board = createBoard(rng, { width: 8, height: 8, allowInitialMatches: false });
 
-  return initCombatState({ hero: params.heroDef, enemy: params.enemyDef, board, rngState: rng.getState() });
+  const enemyDef = selectEnemy({ seed: params.seed, floorIndex: params.floorIndex, floorsCount: params.floorsCount });
+
+  return initCombatState({ hero: params.heroDef, enemy: enemyDef, board, rngState: rng.getState() });
 }

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,6 +1,6 @@
 import './style.css';
 
-import { DEFAULT_ENEMY, DEFAULT_HERO } from './game/combat';
+import { DEFAULT_HERO } from './game/combat';
 import type { CombatState } from './game/combat';
 import { resolvePlayerMove } from './game/combat';
 import { initFloorCombat, initRunState, makeEmptyRunState, runReducer } from './game/run';
@@ -51,7 +51,7 @@ async function main() {
 
   const makePreviewRun = (): RunState => {
     const base = makeEmptyRunState();
-    const combat = initFloorCombat({ seed: defaultSeed, floorIndex: 0, heroDef: DEFAULT_HERO, enemyDef: DEFAULT_ENEMY });
+    const combat = initFloorCombat({ seed: defaultSeed, floorIndex: 0, floorsCount: 5, heroDef: DEFAULT_HERO });
     return { ...base, seed: defaultSeed, combat, screen: 'start' };
   };
 
@@ -67,7 +67,7 @@ async function main() {
     // Ensure we always have a battle state available for rendering, even on Start screen.
     runState = {
       ...runState,
-      combat: initFloorCombat({ seed: runState.seed, floorIndex: runState.floorIndex, heroDef: DEFAULT_HERO, enemyDef: DEFAULT_ENEMY }),
+      combat: initFloorCombat({ seed: runState.seed, floorIndex: runState.floorIndex, floorsCount: runState.config.floorsCount, heroDef: DEFAULT_HERO }),
     };
   }
 
@@ -90,7 +90,7 @@ async function main() {
     if (!runState.combat) {
       runState = {
         ...runState,
-        combat: initFloorCombat({ seed: runState.seed, floorIndex: runState.floorIndex, heroDef: DEFAULT_HERO, enemyDef: DEFAULT_ENEMY }),
+        combat: initFloorCombat({ seed: runState.seed, floorIndex: runState.floorIndex, floorsCount: runState.config.floorsCount, heroDef: DEFAULT_HERO }),
       };
     }
 

--- a/docs/exec-plans/active/EP-0006-enemies.md
+++ b/docs/exec-plans/active/EP-0006-enemies.md
@@ -24,10 +24,21 @@ Add an MVP enemy roster (≥3 enemies + 1 boss) with distinct stats and at least
 ## Tasks
 
 - [ ] Product spec updates: `docs/product-specs/enemies.md`, `docs/product-specs/tiles.md`
-- [ ] Add enemy data + selection
-- [ ] Implement ability triggers (MVP)
+- [ ] EnemyDefs + deterministic selection by floor (issue #31)
+- [ ] Enemy tile weights integration (issue #32)
+- [ ] Enemy abilities (MVP triggers) (issue #33)
 - [ ] Integrate with run loop
 - [ ] Tests + quality gates
+
+## Test cases
+
+- **TC-ENEMY-001: deterministic enemy selection**
+  - Steps: select enemy twice with same (seed,floorIndex)
+  - Expected: same enemy id
+
+- **TC-ENEMY-002: boss appears on last floor**
+  - Steps: select enemy on last floor
+  - Expected: boss id
 
 ## Tests
 


### PR DESCRIPTION
Closes #31.

## What
Introduce data-driven enemy roster and deterministic enemy selection by (seed, floorIndex).

## Changes
- `apps/web/src/game/enemies/*`:
  - Enemy roster defs (3 regular + boss)
  - `selectEnemy()` deterministic selection
- Run initialization now selects enemy via `selectEnemy` (boss on last floor)
- Unit tests for determinism + boss rule
- EP-0006 plan updated with test cases

## QA
- `pnpm -C apps/web lint` ✅
- `pnpm -C apps/web typecheck` ✅
- `pnpm test` ✅
- `pnpm e2e` ✅ (baseline screenshot regression stays green)
