### PR TITLE
fix(run): sync enemyDef with combat enemy when changing floors

### DIFF
--- a/apps/web/src/game/run/reducer.ts
+++ b/apps/web/src/game/run/reducer.ts
@@ -1,6 +1,7 @@
 import type { RunAction, RunState } from './types';
 import { initFloorCombat, initRunState, makeEmptyRunState } from './state';
 import { DEFAULT_HERO } from '../combat';
+import { selectEnemy } from '../enemies';
 import { applyUpgrade } from '../upgrades';
 
 export function runReducer(state: RunState, action: RunAction): RunState {
@@ -20,6 +21,12 @@ export function runReducer(state: RunState, action: RunAction): RunState {
     case 'StartBattle': {
       if (state.endResult) return state;
 
+      const enemyDef = selectEnemy({
+        seed: state.seed,
+        floorIndex: state.floorIndex,
+        floorsCount: state.config.floorsCount,
+      });
+
       const combat = initFloorCombat({
         seed: state.seed,
         floorIndex: state.floorIndex,
@@ -31,6 +38,7 @@ export function runReducer(state: RunState, action: RunAction): RunState {
         ...state,
         screen: 'battle',
         combat,
+        enemyDef,
       };
     }
 
@@ -56,9 +64,12 @@ export function runReducer(state: RunState, action: RunAction): RunState {
 
     case 'NextFloor': {
       const nextFloorIndex = Math.min(state.floorIndex + 1, state.config.floorsCount - 1);
+      const enemyDef = selectEnemy({ seed: state.seed, floorIndex: nextFloorIndex, floorsCount: state.config.floorsCount });
+
       return {
         ...state,
         floorIndex: nextFloorIndex,
+        enemyDef,
         screen: 'battle',
         combat: initFloorCombat({
           seed: state.seed,

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -4,6 +4,7 @@ import { DEFAULT_HERO } from './game/combat';
 import type { CombatState } from './game/combat';
 import { resolvePlayerMove } from './game/combat';
 import { initFloorCombat, initRunState, makeEmptyRunState, runReducer } from './game/run';
+import { selectEnemy } from './game/enemies';
 import type { RunState } from './game/run';
 import { clearRunFromLocalStorage, createOverlays, loadRunFromLocalStorage, saveRunToLocalStorage } from './ui/overlays';
 
@@ -52,7 +53,8 @@ async function main() {
   const makePreviewRun = (): RunState => {
     const base = makeEmptyRunState();
     const combat = initFloorCombat({ seed: defaultSeed, floorIndex: 0, floorsCount: 5, heroDef: DEFAULT_HERO });
-    return { ...base, seed: defaultSeed, combat, screen: 'start' };
+    const enemyDef = selectEnemy({ seed: defaultSeed, floorIndex: 0, floorsCount: 5 });
+    return { ...base, seed: defaultSeed, enemyDef, combat, screen: 'start' };
   };
 
   let runState: RunState = makePreviewRun();
@@ -90,6 +92,7 @@ async function main() {
     if (!runState.combat) {
       runState = {
         ...runState,
+        enemyDef: selectEnemy({ seed: runState.seed, floorIndex: runState.floorIndex, floorsCount: runState.config.floorsCount }),
         combat: initFloorCombat({ seed: runState.seed, floorIndex: runState.floorIndex, floorsCount: runState.config.floorsCount, heroDef: DEFAULT_HERO }),
       };
     }


### PR DESCRIPTION
Addresses review comment from merged PR #34.

## Problem
After introducing floor-based enemy selection, `NextFloor` could update `combat.enemy` but keep stale `RunState.enemyDef`.

## Fix
- Update `enemyDef` in `StartBattle` and `NextFloor` reducer paths.
- Ensure `main.ts` recomputes `enemyDef` when it synthesizes a missing combat state.

## QA
- pnpm lint/typecheck/test ✅
- pnpm e2e ✅
