### PR TITLE
EP-0006.3: Enemy abilities (MVP triggers)

### DIFF
--- a/apps/web/src/game/combat/types.ts
+++ b/apps/web/src/game/combat/types.ts
@@ -1,4 +1,5 @@
 import type { Board, Coord, MatchGroup, TileId, TileWeights } from '../match3';
+import type { EnemyAbility } from '../enemies/defs';
 
 export type DamageType = 'phys' | 'magic';
 
@@ -46,6 +47,9 @@ export type EnemyDef = {
 
   // EP-0006.2: match-3 spawn weights modifiers (applied on top of run config)
   tileWeights?: TileWeights;
+
+  // EP-0006.3: simple enemy abilities
+  ability?: EnemyAbility;
 };
 
 export type BattleStatus = 'active' | 'won' | 'lost';

--- a/apps/web/src/game/enemies/__tests__/abilities.test.ts
+++ b/apps/web/src/game/enemies/__tests__/abilities.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyEnemyAbilities } from '../abilities';
+import { ENEMY_DEF_BY_ID } from '../defs';
+import { initRunState } from '../../run';
+
+describe('applyEnemyAbilities', () => {
+  it('clawRage increases enemyClawWeight on EnemyAttack events', () => {
+    const base = initRunState({ seed: 1, floorsCount: 5 });
+    const mage = ENEMY_DEF_BY_ID['mage'];
+    const s0 = { ...base, enemyDef: mage, config: { ...base.config, enemyClawWeight: 1 } };
+
+    const s1 = applyEnemyAbilities(s0, [{ type: 'EnemyAttack', amount: 1, damageType: 'phys' }]);
+    expect(s1.config.enemyClawWeight).toBe(2);
+  });
+
+  it('does nothing when no EnemyAttack', () => {
+    const base = initRunState({ seed: 1, floorsCount: 5 });
+    const mage = ENEMY_DEF_BY_ID['mage'];
+    const s0 = { ...base, enemyDef: mage, config: { ...base.config, enemyClawWeight: 1 } };
+
+    const s1 = applyEnemyAbilities(s0, [{ type: 'TurnEnded', turnCount: 1 }]);
+    expect(s1.config.enemyClawWeight).toBe(1);
+  });
+});

--- a/apps/web/src/game/enemies/abilities.ts
+++ b/apps/web/src/game/enemies/abilities.ts
@@ -1,0 +1,26 @@
+import type { CombatEvent } from '../combat';
+import type { RunState } from '../run';
+
+export function applyEnemyAbilities(state: RunState, events: CombatEvent[]): RunState {
+  const ability = state.enemyDef.ability;
+  if (!ability || ability.kind === 'none') return state;
+
+  switch (ability.kind) {
+    case 'clawRage': {
+      const attacks = events.filter((e) => e.type === 'EnemyAttack').length;
+      if (attacks <= 0) return state;
+
+      const nextWeight = state.config.enemyClawWeight + attacks * ability.addEnemyClawWeightOnEnemyAttack;
+      return {
+        ...state,
+        config: {
+          ...state.config,
+          enemyClawWeight: nextWeight,
+        },
+      };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/apps/web/src/game/enemies/defs.ts
+++ b/apps/web/src/game/enemies/defs.ts
@@ -1,5 +1,9 @@
 import type { EnemyDef } from '../combat';
 
+export type EnemyAbility =
+  | { kind: 'none' }
+  | { kind: 'clawRage'; addEnemyClawWeightOnEnemyAttack: number };
+
 export const ENEMY_DEFS = [
   {
     id: 'slime',
@@ -8,6 +12,7 @@ export const ENEMY_DEFS = [
     attackEveryTurns: 3,
     attackPower: 7,
     attackType: 'phys',
+    ability: { kind: 'none' },
   },
   {
     id: 'bandit',
@@ -16,6 +21,7 @@ export const ENEMY_DEFS = [
     attackEveryTurns: 2,
     attackPower: 9,
     attackType: 'phys',
+    ability: { kind: 'none' },
   },
   {
     id: 'mage',
@@ -24,6 +30,8 @@ export const ENEMY_DEFS = [
     attackEveryTurns: 2,
     attackPower: 9,
     attackType: 'magic',
+    // Every enemy attack increases harmful enemyClaw tile weight.
+    ability: { kind: 'clawRage', addEnemyClawWeightOnEnemyAttack: 1 },
   },
   {
     id: 'boss',
@@ -32,6 +40,7 @@ export const ENEMY_DEFS = [
     attackEveryTurns: 2,
     attackPower: 12,
     attackType: 'phys',
+    ability: { kind: 'none' },
   },
 ] satisfies EnemyDef[];
 

--- a/apps/web/src/game/enemies/index.ts
+++ b/apps/web/src/game/enemies/index.ts
@@ -1,2 +1,3 @@
 export * from './defs';
 export * from './select';
+export * from './abilities';

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -4,7 +4,7 @@ import { DEFAULT_HERO } from './game/combat';
 import type { CombatState } from './game/combat';
 import { resolvePlayerMove } from './game/combat';
 import { initFloorCombat, initRunState, makeEmptyRunState, runReducer } from './game/run';
-import { selectEnemy } from './game/enemies';
+import { applyEnemyAbilities, ENEMY_DEF_BY_ID, selectEnemy } from './game/enemies';
 import type { RunState } from './game/run';
 import { clearRunFromLocalStorage, createOverlays, loadRunFromLocalStorage, saveRunToLocalStorage } from './ui/overlays';
 
@@ -274,6 +274,9 @@ async function main() {
       // After committing state, it's safe to do a full sync.
       syncLayout({ fullSync: true });
 
+      // Enemy abilities (run-level effects) based on combat events.
+      runState = applyEnemyAbilities(runState, res.events);
+
       // Run-screen transitions (MVP): react to combat status.
       if (state.status === 'won') {
         runState = runReducer(runState, { type: 'BattleEnded', result: 'won' });
@@ -297,6 +300,9 @@ async function main() {
   });
 
   // Debug hooks for Playwright e2e integration tests.
+  // Expose enemy defs for debug (Playwright only)
+  (window as unknown as Record<string, unknown>).__TRR_ENEMIES = ENEMY_DEF_BY_ID;
+
   (window as unknown as Record<string, unknown>).__TRR_DEBUG__ = {
     forceWin: () => {
       state = { ...state, status: 'won' };
@@ -310,6 +316,18 @@ async function main() {
       saveRunToLocalStorage(runState);
       overlays.render(runState);
     },
+    forceEnemyAttack: () => {
+      runState = applyEnemyAbilities(runState, [{ type: 'EnemyAttack', amount: 1, damageType: 'phys' }]);
+      saveRunToLocalStorage(runState);
+      overlays.render(runState);
+    },
+    getEnemyClawWeight: () => runState.config.enemyClawWeight,
+    setEnemy: (enemyId: string) => {
+      const def = ENEMY_DEF_BY_ID[enemyId];
+      if (def) runState = { ...runState, enemyDef: def };
+      overlays.render(runState);
+    },
+
   };
 
   // keep for now

--- a/docs/exec-plans/active/EP-0006-enemies.md
+++ b/docs/exec-plans/active/EP-0006-enemies.md
@@ -40,6 +40,10 @@ Add an MVP enemy roster (≥3 enemies + 1 boss) with distinct stats and at least
   - Steps: select enemy on last floor
   - Expected: boss id
 
+- **TC-ABILITY-001: mage clawRage increases enemyClawWeight after enemy attack**
+  - Steps: set enemy=mage → trigger enemy attack
+  - Expected: runState.config.enemyClawWeight increments
+
 ## Tests
 
 - `pnpm -C apps/web lint`

--- a/tests/e2e/abilities.spec.ts
+++ b/tests/e2e/abilities.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test('abilities: mage clawRage increases enemyClawWeight after enemy attack', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'New Run' }).click();
+
+  // Switch enemy to mage.
+  await page.evaluate(() => {
+    // @ts-expect-error debug
+    window.__TRR_DEBUG__.setEnemy('mage');
+  });
+
+  const w0 = await page.evaluate(() => {
+    // @ts-expect-error debug
+    return window.__TRR_DEBUG__.getEnemyClawWeight();
+  });
+
+  await page.evaluate(() => {
+    // @ts-expect-error debug
+    window.__TRR_DEBUG__.forceEnemyAttack();
+  });
+
+  const w1 = await page.evaluate(() => {
+    // @ts-expect-error debug
+    return window.__TRR_DEBUG__.getEnemyClawWeight();
+  });
+
+  expect(w1).toBeGreaterThan(w0);
+
+  // Baseline still renders.
+  await expect(page.locator('canvas')).toBeVisible();
+});


### PR DESCRIPTION
Closes #33.

## What
Add a simple enemy ability trigger (MVP): mage "clawRage".

### clawRage
On each EnemyAttack event, increase `runState.config.enemyClawWeight` by +1.
This makes harmful tile C spawn more often over time.

## Changes
- EnemyDef now supports `ability`
- Add pure `applyEnemyAbilities(runState, events)`
- Hook ability application in main.ts after resolvePlayerMove
- Add unit tests for ability application
- Add Playwright e2e smoke test for ability via debug hooks
- Update EP-0006 test cases

## QA
- `pnpm -C apps/web lint` ✅
- `pnpm -C apps/web typecheck` ✅
- `pnpm test` ✅
- `pnpm docs:lint` ✅
- `pnpm e2e` ✅ (baseline screenshot regression stays green)
