### PR TITLE
EP-0007.1: RunConfig balance knobs + scaling formulas

### DIFF
--- a/apps/web/src/game/run/persist.ts
+++ b/apps/web/src/game/run/persist.ts
@@ -28,10 +28,20 @@ function isRunStateLike(x: unknown): x is RunState {
   const floorsCount = (cfg as Record<string, unknown>).floorsCount;
   if (typeof floorsCount !== 'number' || !Number.isFinite(floorsCount) || floorsCount < 1) return false;
 
-  // Back-compat: older EP-0004/5 saves won't have this field.
+  // Back-compat: older EP-0004/5 saves won't have these fields.
   const enemyClawWeight = (cfg as Record<string, unknown>).enemyClawWeight;
   if (enemyClawWeight !== undefined) {
     if (typeof enemyClawWeight !== 'number' || !Number.isFinite(enemyClawWeight) || enemyClawWeight <= 0) return false;
+  }
+
+  const enemyPerFloorMultiplier = (cfg as Record<string, unknown>).enemyPerFloorMultiplier;
+  if (enemyPerFloorMultiplier !== undefined) {
+    if (typeof enemyPerFloorMultiplier !== 'number' || !Number.isFinite(enemyPerFloorMultiplier) || enemyPerFloorMultiplier < 0) return false;
+  }
+
+  const bossMultiplier = (cfg as Record<string, unknown>).bossMultiplier;
+  if (bossMultiplier !== undefined) {
+    if (typeof bossMultiplier !== 'number' || !Number.isFinite(bossMultiplier) || bossMultiplier < 1) return false;
   }
 
   // Soft checks for fields used by UI flow.
@@ -64,9 +74,9 @@ export function deserializeRun(raw: string): RunState | null {
       const cfg = (state as Record<string, unknown>).config;
       if (typeof cfg === 'object' && cfg !== null) {
         const cfgObj = cfg as Record<string, unknown>;
-        if (cfgObj.enemyClawWeight === undefined) {
-          cfgObj.enemyClawWeight = 1;
-        }
+        if (cfgObj.enemyClawWeight === undefined) cfgObj.enemyClawWeight = 1;
+        if (cfgObj.enemyPerFloorMultiplier === undefined) cfgObj.enemyPerFloorMultiplier = 0.12;
+        if (cfgObj.bossMultiplier === undefined) cfgObj.bossMultiplier = 1.35;
       }
     }
 

--- a/apps/web/src/game/run/reducer.ts
+++ b/apps/web/src/game/run/reducer.ts
@@ -1,7 +1,6 @@
 import type { RunAction, RunState } from './types';
-import { initFloorCombat, initRunState, makeEmptyRunState } from './state';
+import { initFloorCombat, initRunState, makeEmptyRunState, selectRunEnemyDef } from './state';
 import { DEFAULT_HERO } from '../combat';
-import { selectEnemy } from '../enemies';
 import { applyUpgrade } from '../upgrades';
 
 export function runReducer(state: RunState, action: RunAction): RunState {
@@ -21,10 +20,12 @@ export function runReducer(state: RunState, action: RunAction): RunState {
     case 'StartBattle': {
       if (state.endResult) return state;
 
-      const enemyDef = selectEnemy({
+      const enemyDef = selectRunEnemyDef({
         seed: state.seed,
         floorIndex: state.floorIndex,
         floorsCount: state.config.floorsCount,
+        enemyPerFloorMultiplier: state.config.enemyPerFloorMultiplier,
+        bossMultiplier: state.config.bossMultiplier,
       });
 
       const combat = initFloorCombat({
@@ -67,7 +68,13 @@ export function runReducer(state: RunState, action: RunAction): RunState {
 
     case 'NextFloor': {
       const nextFloorIndex = Math.min(state.floorIndex + 1, state.config.floorsCount - 1);
-      const enemyDef = selectEnemy({ seed: state.seed, floorIndex: nextFloorIndex, floorsCount: state.config.floorsCount });
+      const enemyDef = selectRunEnemyDef({
+        seed: state.seed,
+        floorIndex: nextFloorIndex,
+        floorsCount: state.config.floorsCount,
+        enemyPerFloorMultiplier: state.config.enemyPerFloorMultiplier,
+        bossMultiplier: state.config.bossMultiplier,
+      });
 
       return {
         ...state,

--- a/apps/web/src/game/run/reducer.ts
+++ b/apps/web/src/game/run/reducer.ts
@@ -32,6 +32,8 @@ export function runReducer(state: RunState, action: RunAction): RunState {
         floorIndex: state.floorIndex,
         floorsCount: state.config.floorsCount,
         enemyClawWeight: state.config.enemyClawWeight,
+        enemyPerFloorMultiplier: state.config.enemyPerFloorMultiplier,
+        bossMultiplier: state.config.bossMultiplier,
         heroDef: DEFAULT_HERO,
       });
 
@@ -77,6 +79,8 @@ export function runReducer(state: RunState, action: RunAction): RunState {
           floorIndex: nextFloorIndex,
           floorsCount: state.config.floorsCount,
           enemyClawWeight: state.config.enemyClawWeight,
+          enemyPerFloorMultiplier: state.config.enemyPerFloorMultiplier,
+          bossMultiplier: state.config.bossMultiplier,
           heroDef: DEFAULT_HERO,
         }),
       };

--- a/apps/web/src/game/run/state.ts
+++ b/apps/web/src/game/run/state.ts
@@ -2,6 +2,36 @@ import { createBoard, createRng } from '../match3';
 import { DEFAULT_HERO, initCombatState } from '../combat';
 import { selectEnemy } from '../enemies';
 import { scaleEnemyDef } from '../scaling/enemyScaling';
+
+type EnemyDef = ReturnType<typeof selectEnemy>;
+
+export function selectRunEnemyDef(params: {
+  seed: number;
+  floorIndex: number;
+  floorsCount: number;
+  enemyPerFloorMultiplier: number;
+  bossMultiplier: number;
+}): EnemyDef {
+  const enemyDefRaw = selectEnemy({
+    seed: params.seed,
+    floorIndex: params.floorIndex,
+    floorsCount: params.floorsCount,
+  });
+
+  const isBoss = enemyDefRaw.id === 'boss' && params.floorIndex >= params.floorsCount - 1;
+
+  return scaleEnemyDef({
+    enemy: enemyDefRaw,
+    floorIndex: params.floorIndex,
+    floorsCount: params.floorsCount,
+    cfg: {
+      perFloorMultiplier: params.enemyPerFloorMultiplier,
+      bossMultiplier: params.bossMultiplier,
+      rounding: 'floor',
+    },
+    isBoss,
+  });
+}
 import type { RunConfig, RunState } from './types';
 
 export const RUN_SCHEMA_VERSION = 1 as const;
@@ -16,16 +46,24 @@ export function defaultRunConfig(overrides: Partial<RunConfig> = {}): RunConfig 
 }
 
 export function makeEmptyRunState(): RunState {
+  const config = defaultRunConfig();
+
   return {
     schemaVersion: RUN_SCHEMA_VERSION,
     seed: 0,
-    config: defaultRunConfig(),
+    config,
     screen: 'start',
     floorIndex: 0,
     combat: null,
     endResult: null,
     heroDef: DEFAULT_HERO,
-    enemyDef: selectEnemy({ seed: 0, floorIndex: 0, floorsCount: 5 }),
+    enemyDef: selectRunEnemyDef({
+      seed: 0,
+      floorIndex: 0,
+      floorsCount: config.floorsCount,
+      enemyPerFloorMultiplier: config.enemyPerFloorMultiplier,
+      bossMultiplier: config.bossMultiplier,
+    }),
   };
 }
 
@@ -33,7 +71,13 @@ export function initRunState(params: { seed: number; floorsCount?: number }): Ru
   const config = defaultRunConfig({ floorsCount: params.floorsCount });
 
   const heroDef = DEFAULT_HERO;
-  const enemyDef = selectEnemy({ seed: params.seed, floorIndex: 0, floorsCount: config.floorsCount });
+  const enemyDef = selectRunEnemyDef({
+    seed: params.seed,
+    floorIndex: 0,
+    floorsCount: config.floorsCount,
+    enemyPerFloorMultiplier: config.enemyPerFloorMultiplier,
+    bossMultiplier: config.bossMultiplier,
+  });
 
   return {
     schemaVersion: RUN_SCHEMA_VERSION,
@@ -69,20 +113,13 @@ export function initFloorCombat(params: {
 }) {
   // NOTE: deterministic per floor. For MVP we just offset the seed.
   const rng = createRng((params.seed + params.floorIndex * 10_000) >>> 0);
-  const enemyDefRaw = selectEnemy({ seed: params.seed, floorIndex: params.floorIndex, floorsCount: params.floorsCount });
 
-  // Enemy scaling (EP-0007)
-  const isBoss = enemyDefRaw.id === 'boss' && params.floorIndex >= params.floorsCount - 1;
-  const enemyDef = scaleEnemyDef({
-    enemy: enemyDefRaw,
+  const enemyDef = selectRunEnemyDef({
+    seed: params.seed,
     floorIndex: params.floorIndex,
     floorsCount: params.floorsCount,
-    cfg: {
-      perFloorMultiplier: params.enemyPerFloorMultiplier,
-      bossMultiplier: params.bossMultiplier,
-      rounding: 'floor',
-    },
-    isBoss,
+    enemyPerFloorMultiplier: params.enemyPerFloorMultiplier,
+    bossMultiplier: params.bossMultiplier,
   });
 
   // Enemy tile weight modifiers (MVP: only enemyClaw/C).

--- a/apps/web/src/game/run/state.ts
+++ b/apps/web/src/game/run/state.ts
@@ -1,6 +1,7 @@
 import { createBoard, createRng } from '../match3';
 import { DEFAULT_HERO, initCombatState } from '../combat';
 import { selectEnemy } from '../enemies';
+import { scaleEnemyDef } from '../scaling/enemyScaling';
 import type { RunConfig, RunState } from './types';
 
 export const RUN_SCHEMA_VERSION = 1 as const;
@@ -9,6 +10,8 @@ export function defaultRunConfig(overrides: Partial<RunConfig> = {}): RunConfig 
   return {
     floorsCount: overrides.floorsCount ?? 5,
     enemyClawWeight: overrides.enemyClawWeight ?? 1,
+    enemyPerFloorMultiplier: overrides.enemyPerFloorMultiplier ?? 0.12,
+    bossMultiplier: overrides.bossMultiplier ?? 1.35,
   };
 }
 
@@ -43,6 +46,8 @@ export function initRunState(params: { seed: number; floorsCount?: number }): Ru
       floorIndex: 0,
       floorsCount: config.floorsCount,
       enemyClawWeight: config.enemyClawWeight,
+      enemyPerFloorMultiplier: config.enemyPerFloorMultiplier,
+      bossMultiplier: config.bossMultiplier,
       heroDef,
     }),
     endResult: null,
@@ -55,12 +60,30 @@ export function initFloorCombat(params: {
   seed: number;
   floorIndex: number;
   floorsCount: number;
+
   enemyClawWeight: number;
+  enemyPerFloorMultiplier: number;
+  bossMultiplier: number;
+
   heroDef: typeof DEFAULT_HERO;
 }) {
   // NOTE: deterministic per floor. For MVP we just offset the seed.
   const rng = createRng((params.seed + params.floorIndex * 10_000) >>> 0);
-  const enemyDef = selectEnemy({ seed: params.seed, floorIndex: params.floorIndex, floorsCount: params.floorsCount });
+  const enemyDefRaw = selectEnemy({ seed: params.seed, floorIndex: params.floorIndex, floorsCount: params.floorsCount });
+
+  // Enemy scaling (EP-0007)
+  const isBoss = enemyDefRaw.id === 'boss' && params.floorIndex >= params.floorsCount - 1;
+  const enemyDef = scaleEnemyDef({
+    enemy: enemyDefRaw,
+    floorIndex: params.floorIndex,
+    floorsCount: params.floorsCount,
+    cfg: {
+      perFloorMultiplier: params.enemyPerFloorMultiplier,
+      bossMultiplier: params.bossMultiplier,
+      rounding: 'floor',
+    },
+    isBoss,
+  });
 
   // Enemy tile weight modifiers (MVP: only enemyClaw/C).
   const tileWeights = {

--- a/apps/web/src/game/run/types.ts
+++ b/apps/web/src/game/run/types.ts
@@ -9,6 +9,10 @@ export type RunConfig = {
 
   // EP-0006.2: base weight for enemyClaw tile (C)
   enemyClawWeight: number;
+
+  // EP-0007: enemy scaling
+  enemyPerFloorMultiplier: number;
+  bossMultiplier: number;
 };
 
 export type RunState = {

--- a/apps/web/src/game/scaling/__tests__/enemyScaling.test.ts
+++ b/apps/web/src/game/scaling/__tests__/enemyScaling.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { ENEMY_DEF_BY_ID } from '../../enemies';
+import { scaleEnemyDef } from '../enemyScaling';
+
+describe('scaleEnemyDef', () => {
+  const cfg = { perFloorMultiplier: 0.2, bossMultiplier: 1.5, rounding: 'floor' as const };
+
+  it('is deterministic', () => {
+    const e = ENEMY_DEF_BY_ID['slime'];
+    const a = scaleEnemyDef({ enemy: e, floorIndex: 2, floorsCount: 5, cfg });
+    const b = scaleEnemyDef({ enemy: e, floorIndex: 2, floorsCount: 5, cfg });
+    expect(a).toEqual(b);
+  });
+
+  it('scales up with floors', () => {
+    const e = ENEMY_DEF_BY_ID['slime'];
+    const f0 = scaleEnemyDef({ enemy: e, floorIndex: 0, floorsCount: 5, cfg });
+    const f4 = scaleEnemyDef({ enemy: e, floorIndex: 4, floorsCount: 5, cfg });
+    expect(f4.baseStats.hpMax ?? 0).toBeGreaterThanOrEqual(f0.baseStats.hpMax ?? 0);
+    expect(f4.baseStats.atk ?? 0).toBeGreaterThanOrEqual(f0.baseStats.atk ?? 0);
+  });
+
+  it('boss uses boss multiplier', () => {
+    const e = ENEMY_DEF_BY_ID['boss'];
+    const a = scaleEnemyDef({ enemy: e, floorIndex: 4, floorsCount: 5, cfg, isBoss: true });
+    const b = scaleEnemyDef({ enemy: e, floorIndex: 4, floorsCount: 5, cfg, isBoss: false });
+    expect(a.baseStats.hpMax ?? 0).toBeGreaterThan(b.baseStats.hpMax ?? 0);
+  });
+});

--- a/apps/web/src/game/scaling/enemyScaling.ts
+++ b/apps/web/src/game/scaling/enemyScaling.ts
@@ -1,0 +1,53 @@
+import type { EnemyDef } from '../combat';
+
+export type EnemyScalingConfig = {
+  // Multiplier per floor (e.g. 0.12 => +12% per floor)
+  perFloorMultiplier: number;
+  bossMultiplier: number;
+
+  // Round strategy: 'floor' to keep integers
+  rounding?: 'floor' | 'round' | 'ceil';
+};
+
+function round(n: number, mode: EnemyScalingConfig['rounding']): number {
+  switch (mode) {
+    case 'ceil':
+      return Math.ceil(n);
+    case 'round':
+      return Math.round(n);
+    case 'floor':
+    default:
+      return Math.floor(n);
+  }
+}
+
+export function scaleEnemyDef(params: {
+  enemy: EnemyDef;
+  floorIndex: number;
+  floorsCount: number;
+  cfg: EnemyScalingConfig;
+  isBoss?: boolean;
+}): EnemyDef {
+  const { enemy, floorIndex, cfg } = params;
+
+  const f = Math.max(0, floorIndex);
+  const mult = 1 + cfg.perFloorMultiplier * f;
+  const bossMult = params.isBoss ? cfg.bossMultiplier : 1;
+  const m = mult * bossMult;
+
+  const rounding = cfg.rounding ?? 'floor';
+
+  const hpMax0 = enemy.baseStats.hpMax ?? 0;
+  const atk0 = enemy.baseStats.atk ?? 0;
+
+  return {
+    ...enemy,
+    baseStats: {
+      ...enemy.baseStats,
+      hpMax: round(hpMax0 * m, rounding),
+      atk: round(atk0 * m, rounding),
+    },
+    // Keep attack cadence; scale power slightly.
+    attackPower: round(enemy.attackPower * m, rounding),
+  };
+}

--- a/apps/web/src/game/scaling/index.ts
+++ b/apps/web/src/game/scaling/index.ts
@@ -1,0 +1,1 @@
+export * from './enemyScaling';

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -52,7 +52,15 @@ async function main() {
 
   const makePreviewRun = (): RunState => {
     const base = makeEmptyRunState();
-    const combat = initFloorCombat({ seed: defaultSeed, floorIndex: 0, floorsCount: 5, enemyClawWeight: 1, heroDef: DEFAULT_HERO });
+    const combat = initFloorCombat({
+      seed: defaultSeed,
+      floorIndex: 0,
+      floorsCount: 5,
+      enemyClawWeight: 1,
+      enemyPerFloorMultiplier: 0.12,
+      bossMultiplier: 1.35,
+      heroDef: DEFAULT_HERO,
+    });
     const enemyDef = selectEnemy({ seed: defaultSeed, floorIndex: 0, floorsCount: 5 });
     return { ...base, seed: defaultSeed, enemyDef, combat, screen: 'start' };
   };
@@ -74,6 +82,8 @@ async function main() {
         floorIndex: runState.floorIndex,
         floorsCount: runState.config.floorsCount,
         enemyClawWeight: runState.config.enemyClawWeight,
+        enemyPerFloorMultiplier: runState.config.enemyPerFloorMultiplier,
+        bossMultiplier: runState.config.bossMultiplier,
         heroDef: DEFAULT_HERO,
       }),
     };
@@ -104,6 +114,8 @@ async function main() {
           floorIndex: runState.floorIndex,
           floorsCount: runState.config.floorsCount,
           enemyClawWeight: runState.config.enemyClawWeight,
+          enemyPerFloorMultiplier: runState.config.enemyPerFloorMultiplier,
+          bossMultiplier: runState.config.bossMultiplier,
           heroDef: DEFAULT_HERO,
         }),
       };

--- a/docs/exec-plans/active/EP-0007-scaling-map-lite.md
+++ b/docs/exec-plans/active/EP-0007-scaling-map-lite.md
@@ -23,10 +23,24 @@ Define a small run structure (MVP: 5 floors) with deterministic floor progressio
 
 ## Tasks
 
-- [ ] Consolidate balance knobs into RunConfig
-- [ ] Implement scaling
-- [ ] Map-lite UI
+- [ ] RunConfig balance knobs + scaling formulas (issue #39)
+- [ ] Map-lite UI (issue #40)
+- [ ] Optional enemy choice (2 options) (issue #41)
 - [ ] Tests + docs updates
+
+## Test cases
+
+- **TC-SCALE-001: scaling is deterministic**
+  - Steps: compute scaled enemy twice for same (enemyId, floorIndex, config)
+  - Expected: identical stats
+
+- **TC-SCALE-002: hp/atk scale up with floors**
+  - Steps: compare scaled stats on floor 0 vs floor 4
+  - Expected: floor 4 >= floor 0
+
+- **TC-SCALE-003: boss scaling uses boss multiplier**
+  - Steps: scale boss enemy on last floor
+  - Expected: boss stats reflect multiplier
 
 ## Tests
 


### PR DESCRIPTION
Closes #39.

## What
Introduce deterministic enemy scaling and consolidate balance knobs into RunConfig.

## Changes
- Add scaling module: `apps/web/src/game/scaling/enemyScaling.ts`
- RunConfig extended:
  - enemyPerFloorMultiplier
  - bossMultiplier
- Run init/combat creation uses scaled enemy def per floor
- Persistence: back-compat migrate missing scaling fields to defaults
- Tests: unit scaling determinism + monotonicity + boss multiplier
- Update EP-0007 plan with tasks + test cases

## QA
- `pnpm -C apps/web lint` ✅
- `pnpm -C apps/web typecheck` ✅
- `pnpm test` ✅
- `pnpm docs:lint` ✅
- `pnpm e2e` ✅ (baseline screenshot regression stays green)
